### PR TITLE
Tweak testFloatValue so that it fails

### DIFF
--- a/Tests/UnitTests/NullTests.m
+++ b/Tests/UnitTests/NullTests.m
@@ -20,8 +20,9 @@
 - (void)testFloatValue
 {
     id nullValue = [NSNull null];
+    float x = floorf(123.456);
     float result = [nullValue floatValue];
-    NSAssert(result == 0.0f, @"FloatValue test failed");
+    NSAssert(result == 0.0f, @"FloatValue test failed (%g)", x);
 }
 
 - (void)testClass


### PR DESCRIPTION
Hint: you add the methods with `NUSNullSafeMethodIMP` implementation but its signature is not `v@:@` ⇒ bad things will ensue. I think the only sensible route to this problem is `forwardInvocation:`.
