### PR TITLE
Fixing xcode 7 warning

### DIFF
--- a/NullSafe/NullSafe.m
+++ b/NullSafe/NullSafe.m
@@ -123,7 +123,7 @@
     }
 }
 
-- (void)forwardInvocation:(NSInvocation *)invocation
+- (void)forwardInvocation:(NSInvocation * __unused)invocation
 {
 }
 

--- a/NullSafe/NullSafe.m
+++ b/NullSafe/NullSafe.m
@@ -125,7 +125,6 @@
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-    [invocation invoke];
 }
 
 #endif

--- a/NullSafe/NullSafe.m
+++ b/NullSafe/NullSafe.m
@@ -125,7 +125,7 @@
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-    [invocation invokeWithTarget:nil];
+    [invocation invoke];
 }
 
 #endif


### PR DESCRIPTION
Replacing call to `[invocation invokeWithTarget: nil]` with `[invocation invoke]`.

For issue https://github.com/nicklockwood/NullSafe/issues/4